### PR TITLE
Update Nginx service port mapping from 3080 to 3081

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,6 @@ services:
     env_file:
       - .env
     ports:
-      - "3080:80"
+      - "3081:80"
     networks:
       - releve2024-network


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change updates the port mapping for the service from `3080:80` to `3081:80`