### PR TITLE
Update scholarship recipients for the 2025 year in Home.tsx

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,7 +26,16 @@ interface YearData {
 const scholarshipData: YearData[] = [
   {
     year: 2025,
-    recipients: ["To be announced soon!"],
+    recipients: [
+      "Elisandra von Doymi",
+      "Jordyn Jiries",
+      "Jacob Klesert",
+      "Syra Merchant",
+      "Zoë Morgan",
+      "Sophia Peabody",
+      "Katelyn Rumm",
+      "Fiona Yick",
+    ],
     nominees: [
       "Bella Apaez",
       "Yvanna Apaez",


### PR DESCRIPTION
This pull request updates the `src/pages/Home.tsx` file to include the list of scholarship recipients for the year 2025.

* [`src/pages/Home.tsx`](diffhunk://#diff-e41191ca0fedc3d7c9cfce4db24a281797128fbd57681267d583ba9e01069a0eL29-R38): Updated the `recipients` field for the year 2025 in the `scholarshipData` array to include the names of eight recipients: Elisandra von Doymi, Jordyn Jiries, Jacob Klesert, Syra Merchant, Zoë Morgan, Sophia Peabody, Katelyn Rumm, and Fiona Yick.