### PR TITLE
Add 2026 nominees to Scholarship History

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,6 +25,38 @@ interface YearData {
 
 const scholarshipData: YearData[] = [
   {
+    year: 2026,
+    recipients: ["TBA"],
+    nominees: [
+      "Abigail Lucero",
+      "Abigail Maman",
+      "Aleena Bido",
+      "Amayah Gibson",
+      "Amelia Johnston",
+      "Andrea Saldivar",
+      "Avery Clayton",
+      "Bella Apaez",
+      "Charlie Webb",
+      "Chloe Casasola",
+      "Giuliana Collins",
+      "Jacob Rosario",
+      "Jeilyn Rosario",
+      "Kinsley Valentine",
+      "Leah Collier",
+      "Leah Perez",
+      "Leah Quirarte",
+      "Maryah Willis",
+      "Molly Icenbice",
+      "Nicole Torres",
+      "Ruby Ramos",
+      "Sophia Axarlian",
+      "Sylvia Donahue",
+      "Tessa Gagne",
+      "Therese Dizon",
+      "Yvanna Apaez",
+    ],
+  },
+  {
     year: 2025,
     recipients: [
       "Elisandra von Doymi",


### PR DESCRIPTION
## Summary
- Adds the **2026** entry to the Scholarship History on the Home page
- Includes all **26 nominees** from the official student list, sorted alphabetically by first name (matching existing convention)
- **Recipients marked `TBA`** — recipients not yet selected

## Proofing
Nominee names were proofed against `student-list.xlsx`:
- 24 of 26 matched exactly
- **Sylvia Donahue** — corrected spelling from "Silvia" (and resorted alphabetically)
- **Maryah Willis** — confirmed correct (list shows "Maryah C Willis" with middle initial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)