### PR TITLE
Add 2026 nominees to Scholarship History and Home.tsx

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,6 +25,38 @@ interface YearData {
 
 const scholarshipData: YearData[] = [
   {
+    year: 2026,
+    recipients: ["TBA"],
+    nominees: [
+      "Abigail Lucero",
+      "Abigail Maman",
+      "Aleena Bido",
+      "Amayah Gibson",
+      "Amelia Johnston",
+      "Andrea Saldivar",
+      "Avery Clayton",
+      "Bella Apaez",
+      "Charlie Webb",
+      "Chloe Casasola",
+      "Giuliana Collins",
+      "Jacob Rosario",
+      "Jeilyn Rosario",
+      "Kinsley Valentine",
+      "Leah Collier",
+      "Leah Perez",
+      "Leah Quirarte",
+      "Maryah Willis",
+      "Molly Icenbice",
+      "Nicole Torres",
+      "Ruby Ramos",
+      "Sophia Axarlian",
+      "Sylvia Donahue",
+      "Tessa Gagne",
+      "Therese Dizon",
+      "Yvanna Apaez",
+    ],
+  },
+  {
     year: 2025,
     recipients: [
       "Elisandra von Doymi",


### PR DESCRIPTION
This pull request updates the `scholarshipData` array in `src/pages/Home.tsx` by adding information for the year 2026. The new entry includes a placeholder recipient and a list of nominees.

Data updates:

* Added a new `YearData` entry for 2026, with `"TBA"` as the recipient and a full list of nominees.