### PR TITLE
Add 2026 scholarship recipients (replace TBA)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,7 +26,14 @@ interface YearData {
 const scholarshipData: YearData[] = [
   {
     year: 2026,
-    recipients: ["TBA"],
+    recipients: [
+      "Abigail Lucero",
+      "Giuliana Collins",
+      "Jacob Rosario",
+      "Leah Collier",
+      "Leah Quirarte",
+      "Sylvia Donahue",
+    ],
     nominees: [
       "Abigail Lucero",
       "Abigail Maman",


### PR DESCRIPTION
## Summary
Replaces the 2026 **TBA** recipients placeholder with the six selected scholarship recipients on the Home page.

**2026 Recipients:**
- Abigail Lucero
- Giuliana Collins
- Jacob Rosario
- Leah Collier
- Leah Quirarte
- Sylvia Donahue

Sorted alphabetically by first name. All names were previously verified against `student-list.xlsx` as part of the nominee list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)