### PR TITLE
Add 2026 scholarship recipients and replace TBA placeholders

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,7 +26,14 @@ interface YearData {
 const scholarshipData: YearData[] = [
   {
     year: 2026,
-    recipients: ["TBA"],
+    recipients: [
+      "Abigail Lucero",
+      "Giuliana Collins",
+      "Jacob Rosario",
+      "Leah Collier",
+      "Leah Quirarte",
+      "Sylvia Donahue",
+    ],
     nominees: [
       "Abigail Lucero",
       "Abigail Maman",


### PR DESCRIPTION
This pull request updates the `scholarshipData` for the year 2026 in `src/pages/Home.tsx` by replacing the placeholder "TBA" with the actual list of scholarship recipients.

- Data update:
  * The `recipients` field for 2026 now lists the actual recipients: Abigail Lucero, Giuliana Collins, Jacob Rosario, Leah Collier, Leah Quirarte, and Sylvia Donahue, instead of "TBA".